### PR TITLE
refactor: combine two steps: start the server and wait-port

### DIFF
--- a/.github/workflows/tests-13-sprint.yml
+++ b/.github/workflows/tests-13-sprint.yml
@@ -48,11 +48,9 @@ jobs:
       run: make proj13-prepare-test-endpoints
     - name: Installing Dependencies
       run: npm i
-    - name: Run server
-      run: npm run start &
     - name: Installing wait-port
       run: npm install -g wait-port
-    - name: Wait for server to start
-      run: wait-port -t 30000 localhost:3000
+    - name: Run server
+      run: npm run start & wait-port -t 30000 localhost:3000
     - name: Run test config
       run: make proj13-test-endpoints

--- a/.github/workflows/tests-14-sprint.yml
+++ b/.github/workflows/tests-14-sprint.yml
@@ -45,11 +45,9 @@ jobs:
       run: cp ./web-autotest-public/Makefile ./Makefile
     - name: Installing Dependencies
       run: npm i
-    - name: Run server
-      run: npm run start &
     - name: Installing wait-port
       run: npm install -g wait-port
-    - name: Wait for server to start
-      run: wait-port -t 30000 localhost:3000
+    - name: Run server
+      run: npm run start & wait-port -t 30000 localhost:3000
     - name: Run test endpoints
       run: make proj14-test-endpoints


### PR DESCRIPTION
Объединил запуск сервера и проверку его доступности, чтобы, если сервер упадёт, можно было увидеть причину. Сейчас же, Run server всегда отрабатывает без ошибок.